### PR TITLE
fix: Enable config flow for UI configuration

### DIFF
--- a/custom_components/leneda/manifest.json
+++ b/custom_components/leneda/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "leneda",
   "name": "Leneda",
+  "config_flow": true,
   "documentation": "https://leneda.eu/en/docs/api-reference.html",
   "issue_tracker": "",
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }


### PR DESCRIPTION
This commit adds `"config_flow": true` to the `manifest.json` file. This allows the integration to be configured through the Home Assistant UI. This fixes the "This integration cannot be added from the UI" error.

Bumps the integration version to 0.1.2.