### PR TITLE
fix: Add debug logging for diagnostics

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -1,6 +1,7 @@
 """The Leneda integration."""
 from __future__ import annotations
 
+import logging
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -14,9 +15,12 @@ from .const import (
     DOMAIN,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Leneda from a config entry."""
+    _LOGGER.debug("Setting up Leneda integration.")
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = LenedaApiClient(
         session=async_get_clientsession(hass),

--- a/custom_components/leneda/config_flow.py
+++ b/custom_components/leneda/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Leneda."""
+import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -13,6 +14,8 @@ from .const import (
     OBIS_CODES,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Leneda."""
@@ -21,6 +24,7 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        _LOGGER.debug("Leneda config flow started.")
         errors = {}
         if user_input is not None:
             try:

--- a/custom_components/leneda/manifest.json
+++ b/custom_components/leneda/manifest.json
@@ -7,5 +7,5 @@
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }


### PR DESCRIPTION
This commit adds debug logging to the `__init__.py` and `config_flow.py` files. This is intended to help diagnose a silent failure where the integration is failing to set up without any logs.

The new log messages will indicate if the `async_setup_entry` and `async_step_user` functions are being called.

Bumps the integration version to 0.1.3.