### PR TITLE
fix: Refactor to remove circular import

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -2,16 +2,14 @@
 from __future__ import annotations
 
 import logging
-import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import LenedaApiClient
 from .const import (
-    API_BASE_URL,
     CONF_API_KEY,
     CONF_ENERGY_ID,
-    CONF_METERING_POINT_ID,
     DOMAIN,
 )
 
@@ -42,29 +40,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class LenedaApiClient:
-    """A simple API client for the Leneda API."""
-
-    def __init__(self, session: aiohttp.ClientSession, api_key: str, energy_id: str):
-        """Initialize the API client."""
-        self._session = session
-        self._api_key = api_key
-        self._energy_id = energy_id
-
-    async def async_get_metering_data(
-        self, metering_point_id: str, obis_code: str, start_date: str, end_date: str
-    ) -> dict:
-        """Fetch metering data from the Leneda API."""
-        headers = {"X-API-KEY": self._api_key, "X-ENERGY-ID": self._energy_id}
-        params = {
-            "startDateTime": f"{start_date}Z",
-            "endDateTime": f"{end_date}Z",
-            "obisCode": obis_code,
-        }
-        url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series"
-
-        async with self._session.get(url, headers=headers, params=params) as response:
-            response.raise_for_status()
-            return await response.json()

--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -1,0 +1,30 @@
+"""API client for the Leneda API."""
+import aiohttp
+
+from .const import API_BASE_URL
+
+
+class LenedaApiClient:
+    """A simple API client for the Leneda API."""
+
+    def __init__(self, session: aiohttp.ClientSession, api_key: str, energy_id: str):
+        """Initialize the API client."""
+        self._session = session
+        self._api_key = api_key
+        self._energy_id = energy_id
+
+    async def async_get_metering_data(
+        self, metering_point_id: str, obis_code: str, start_date: str, end_date: str
+    ) -> dict:
+        """Fetch metering data from the Leneda API."""
+        headers = {"X-API-KEY": self._api_key, "X-ENERGY-ID": self._energy_id}
+        params = {
+            "startDateTime": f"{start_date}Z",
+            "endDateTime": f"{end_date}Z",
+            "obisCode": obis_code,
+        }
+        url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series"
+
+        async with self._session.get(url, headers=headers, params=params) as response:
+            response.raise_for_status()
+            return await response.json()

--- a/custom_components/leneda/manifest.json
+++ b/custom_components/leneda/manifest.json
@@ -7,5 +7,5 @@
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .const import CONF_METERING_POINT_ID, DOMAIN, OBIS_CODES
-from . import LenedaApiClient
+from .api import LenedaApiClient
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This commit refactors the code to eliminate a circular import between `__init__.py` and `sensor.py`.

The `LenedaApiClient` class has been moved from `__init__.py` to a new `api.py` file. Both `__init__.py` and `sensor.py` now import the API client from `api.py`.

This should resolve the silent "Failed to set up" error.

Bumps the integration version to 0.1.5.