### PR TITLE
Fix Leneda integration setup failure

### DIFF
--- a/custom_components/leneda/config_flow.py
+++ b/custom_components/leneda/config_flow.py
@@ -5,13 +5,12 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import LenedaApiClient
 from .const import (
-    API_BASE_URL,
     CONF_API_KEY,
     CONF_ENERGY_ID,
     CONF_METERING_POINT_ID,
     DOMAIN,
-    OBIS_CODES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,22 +50,7 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _test_credentials(self, api_key, energy_id, metering_point_id):
         """Test credentials against Leneda API."""
-        from datetime import timedelta
-        from homeassistant.util import dt as dt_util
-
         session = async_get_clientsession(self.hass)
-        headers = {"X-API-KEY": api_key, "X-ENERGY-ID": energy_id}
-        obis_code = list(OBIS_CODES.keys())[0]
-        now = dt_util.utcnow()
-        start_date = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-        end_date = now.strftime("%Y-%m-%dT%H:%M:%S")
-
-        params = {
-            "startDateTime": f"{start_date}Z",
-            "endDateTime": f"{end_date}Z",
-            "obisCode": obis_code,
-        }
-        url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series"
-
-        async with session.get(url, headers=headers, params=params) as response:
-            response.raise_for_status()
+        client = LenedaApiClient(session, api_key, energy_id)
+        if not await client.test_credentials(metering_point_id):
+            raise Exception("Cannot connect")

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -68,8 +68,8 @@ class LenedaSensor(SensorEntity):
     async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
         now = dt_util.utcnow()
-        start_date = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-        end_date = now.strftime("%Y-%m-%dT%H:%M:%S")
+        start_date = now - timedelta(hours=1)
+        end_date = now
 
         try:
             data = await self._api_client.async_get_metering_data(


### PR DESCRIPTION
The Leneda integration was failing to set up correctly because of an issue with the API calls. The `startDateTime` and `endDateTime` parameters were not being formatted correctly according to the API documentation.

This change refactors the API calling logic to be centralized within the `LenedaApiClient` class. The `async_get_metering_data` method now accepts datetime objects and formats them to the required `YYYY-MM-DDTHH:MM:SSZ` format.

The `config_flow.py` has been updated to use a new `test_credentials` method in the API client, removing duplicated logic and ensuring that the API calls made during configuration are consistent with those made during sensor updates.

The `sensor.py` has also been updated to pass datetime objects to the API client, completing the refactoring.

This should resolve the setup failure and allow sensors to be created correctly.