### PR TITLE
Add detailed logging for setup debugging

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -26,6 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         energy_id=entry.data[CONF_ENERGY_ID],
     )
 
+    _LOGGER.debug("Forwarding setup to sensor platform.")
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "sensor")
     )

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -35,6 +35,7 @@ async def async_setup_entry(
         for obis_code, details in OBIS_CODES.items()
     ]
     _LOGGER.debug(f"Found {len(sensors)} sensors to create.")
+    _LOGGER.debug("Adding sensor entities.")
     async_add_entities(sensors, True)
     _LOGGER.debug("Finished setting up Leneda sensor platform.")
 


### PR DESCRIPTION
To diagnose a setup failure that is not producing error logs, this change adds more detailed debug logging to the integration setup process.

- A debug log is added in `__init__.py` before forwarding the setup to the sensor platform.
- A debug log is added in `sensor.py` before the sensor entities are added.

This will help trace the execution flow and identify the exact point of failure.