### PR TITLE
Debug: Make sensor platform setup synchronous

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -27,9 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     _LOGGER.debug("Forwarding setup to sensor platform.")
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
 
     return True
 


### PR DESCRIPTION
To help diagnose a setup failure where no errors are being logged, this change makes the sensor platform setup synchronous.

By changing `hass.async_create_task` to `await`, any exceptions that occur during the setup of the sensor platform should now be propagated up and logged, which will help in identifying the root cause of the problem.