### PR TITLE
Fix: Explicitly declare sensor platform in manifest

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -27,7 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     _LOGGER.debug("Forwarding setup to sensor platform.")
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    )
 
     return True
 

--- a/custom_components/leneda/manifest.json
+++ b/custom_components/leneda/manifest.json
@@ -7,5 +7,8 @@
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.1.5"
+  "version": "0.1.5",
+  "platforms": [
+    "sensor"
+  ]
 }


### PR DESCRIPTION
The integration setup was failing to load the sensor platform because it was not explicitly declared in the `manifest.json` file. This was causing the platform forwarding to fail silently.

This change adds `"platforms": ["sensor"]` to the manifest to ensure that Home Assistant is aware of the sensor platform and can load it correctly.

The synchronous debugging change in `__init__.py` has also been reverted to the standard asynchronous setup.