### PR TITLE
Debug: Disable sensor platform to isolate crash

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -26,10 +26,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         energy_id=entry.data[CONF_ENERGY_ID],
     )
 
-    _LOGGER.debug("Forwarding setup to sensor platform.")
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    # _LOGGER.debug("Forwarding setup to sensor platform.")
+    # hass.async_create_task(
+    #     hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    # )
 
     return True
 


### PR DESCRIPTION
As a diagnostic step to locate a potential system crash during setup, this change disables the forwarding of the setup to the sensor platform.

The lines in `__init__.py` that load the sensor platform have been commented out.

This will allow us to determine if the base integration can be loaded without causing a crash. If it succeeds, the problem is confirmed to be within the sensor platform loading process.