### PR TITLE
Debug: Test loading of sensor.py

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -26,10 +26,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         energy_id=entry.data[CONF_ENERGY_ID],
     )
 
-    # _LOGGER.debug("Forwarding setup to sensor platform.")
-    # hass.async_create_task(
-    #     hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    # )
+    _LOGGER.debug("Forwarding setup to sensor platform.")
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    )
 
     return True
 

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -27,17 +27,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up Leneda sensors from a config entry."""
     _LOGGER.debug("Setting up Leneda sensor platform.")
-    api_client: LenedaApiClient = hass.data[DOMAIN][entry.entry_id]
-    metering_point_id = entry.data[CONF_METERING_POINT_ID]
+    _LOGGER.debug("Leneda sensor platform loaded, but sensor creation is disabled for debugging.")
+    # api_client: LenedaApiClient = hass.data[DOMAIN][entry.entry_id]
+    # metering_point_id = entry.data[CONF_METERING_POINT_ID]
 
-    sensors = [
-        LenedaSensor(api_client, metering_point_id, obis_code, details)
-        for obis_code, details in OBIS_CODES.items()
-    ]
-    _LOGGER.debug(f"Found {len(sensors)} sensors to create.")
-    _LOGGER.debug("Adding sensor entities.")
-    async_add_entities(sensors, True)
-    _LOGGER.debug("Finished setting up Leneda sensor platform.")
+    # sensors = [
+    #     LenedaSensor(api_client, metering_point_id, obis_code, details)
+    #     for obis_code, details in OBIS_CODES.items()
+    # ]
+    # _LOGGER.debug(f"Found {len(sensors)} sensors to create.")
+    # _LOGGER.debug("Adding sensor entities.")
+    # async_add_entities(sensors, True)
+    # _LOGGER.debug("Finished setting up Leneda sensor platform.")
 
 
 class LenedaSensor(SensorEntity):


### PR DESCRIPTION
As the next step in diagnosing a system crash, this change re-enables the sensor platform forwarding but disables the sensor creation logic within `sensor.py`.

The goal is to test if the crash is caused by the mere act of importing the `sensor.py` module, or if it is caused by the code within its `async_setup_entry` function.

If this version loads without crashing, it proves the `sensor.py` module itself is fine, and the problem lies in the sensor instantiation or adding process.