### PR TITLE
Fix component crash by using standard platform setup

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -15,6 +16,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Leneda from a config entry."""
@@ -26,17 +29,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         energy_id=entry.data[CONF_ENERGY_ID],
     )
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    if unload_ok:
+    if unload_ok := await hass.config_entries.async_forward_entry_unload(
+        entry, PLATFORMS
+    ):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok


### PR DESCRIPTION
The Leneda custom component was causing Home Assistant to crash on startup. This was due to an improper method of loading the sensor platform.

The `async_setup_entry` function in `__init__.py` was using `hass.async_create_task` to load the sensor platform. This is not the recommended approach and can lead to race conditions and instability.

This commit refactors the platform loading mechanism to follow current Home Assistant best practices:
- A `PLATFORMS` constant is introduced.
- `async_setup_entry` now uses `await hass.config_entries.async_forward_entry_setups` to ensure platforms are loaded correctly and awaited.
- `async_unload_entry` is updated to use the corresponding `async_forward_entry_unload` for consistency.

This change should resolve the crashing issue and make the component more stable.