### PR TITLE
Fix(leneda): Correct API calls and add device info

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -1,7 +1,10 @@
 """The Leneda integration."""
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -28,6 +31,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key=entry.data[CONF_API_KEY],
         energy_id=entry.data[CONF_ENERGY_ID],
     )
+
+    manifest_path = Path(__file__).parent / "manifest.json"
+    with manifest_path.open() as manifest_file:
+        manifest_data = json.load(manifest_file)
+    hass.data[DOMAIN]["version"] = manifest_data.get("version")
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/leneda/manifest.json
+++ b/custom_components/leneda/manifest.json
@@ -7,5 +7,5 @@
   "codeowners": [],
   "requirements": [],
   "iot_class": "cloud_polling",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }


### PR DESCRIPTION
This commit fixes a critical bug where all API calls were being made to the aggregated endpoint due to a duplicated function in the API client. This resulted in sensors not receiving the correct data.

Additionally, this change implements a device page for the integration by adding `device_info` to the sensor entities. This groups all sensors under a single device in Home Assistant, improving the user experience.

The integration version has been bumped to 0.1.7 to ensure the update is detected.