### PR TITLE
Fix(leneda): Correct API endpoint usage for all sensors

### DIFF
--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -78,27 +78,17 @@ class LenedaSensor(SensorEntity):
     async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
         now = dt_util.utcnow()
-        start_date = now - timedelta(days=1)
+        start_date = now - timedelta(hours=25)
         end_date = now
 
         try:
-            if self._attr_native_unit_of_measurement == "kWh":
-                data = await self._api_client.async_get_aggregated_metering_data(
-                    self._metering_point_id, self._obis_code, start_date, end_date
-                )
-                if data and data.get("aggregatedTimeSeries"):
-                    self._attr_native_value = data["aggregatedTimeSeries"][0]["value"]
-                else:
-                    self._attr_native_value = None
+            data = await self._api_client.async_get_metering_data(
+                self._metering_point_id, self._obis_code, start_date, end_date
+            )
+            if data and data.get("items"):
+                self._attr_native_value = data["items"][-1]["value"]
             else:
-                start_date = now - timedelta(hours=1)
-                data = await self._api_client.async_get_metering_data(
-                    self._metering_point_id, self._obis_code, start_date, end_date
-                )
-                if data and data.get("items"):
-                    self._attr_native_value = data["items"][-1]["value"]
-                else:
-                    self._attr_native_value = None
+                self._attr_native_value = None
         except Exception as e:
             _LOGGER.error("Error fetching data for sensor %s: %s", self.name, e)
             self._attr_native_value = None


### PR DESCRIPTION
The Leneda sensors were all showing 'unknown' because of an incorrect API call for sensors with a 'kWh' unit.

The `async_update` method in `sensor.py` was attempting to call the `async_get_aggregated_metering_data` endpoint for the 'Measured Consumed Energy' sensor. However, according to the Leneda API documentation, this endpoint is designed to aggregate data from OBIS codes in 'kW' to produce a 'kWh' value. Calling it with an OBIS code that is already in 'kWh' resulted in an API error, which caused the sensor to fail and likely prevented other sensors from updating correctly.

This commit refactors the `async_update` method to use the standard `async_get_metering_data` endpoint for all sensors. This is the correct approach, as this endpoint retrieves the latest value for any given OBIS code in its native unit. This ensures that all sensors, including power, energy, and volume, now fetch their data correctly.

Additionally, the data fetching window has been increased to 25 hours to make it more robust against potential data delays from the meter.