### PR TITLE
Feat(leneda): Add enhanced API logging for diagnostics

### DIFF
--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -32,7 +32,12 @@ class LenedaApiClient:
         url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series"
 
         async with self._session.get(url, headers=headers, params=params) as response:
-            response.raise_for_status()
+            if response.status != 200:
+                return {
+                    "error": True,
+                    "status": response.status,
+                    "text": await response.text(),
+                }
             return await response.json()
 
     async def async_get_aggregated_metering_data(
@@ -54,7 +59,12 @@ class LenedaApiClient:
         url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series/aggregated"
 
         async with self._session.get(url, headers=headers, params=params) as response:
-            response.raise_for_status()
+            if response.status != 200:
+                return {
+                    "error": True,
+                    "status": response.status,
+                    "text": await response.text(),
+                }
             return await response.json()
 
     async def test_credentials(self, metering_point_id: str) -> bool:
@@ -64,10 +74,9 @@ class LenedaApiClient:
         end_date = now
         obis_code = list(OBIS_CODES.keys())[0]
 
-        try:
-            await self.async_get_metering_data(
-                metering_point_id, obis_code, start_date, end_date
-            )
-        except Exception:
+        data = await self.async_get_metering_data(
+            metering_point_id, obis_code, start_date, end_date
+        )
+        if data.get("error"):
             return False
         return True


### PR DESCRIPTION
This commit adds detailed logging to the Leneda integration to help diagnose issues with specific sensor types, particularly the 'kWh' and volume sensors. This is a diagnostic build and not a final fix.

Changes:
- The LenedaApiClient in `api.py` now gracefully handles non-200 HTTP responses. Instead of raising an exception, it returns a dictionary containing the status code and response text.
- The `test_credentials` function has been updated to be compatible with this new error handling mechanism.
- The `LenedaSensor` in `sensor.py` has been updated to check for and log these detailed API errors. It will also log the full API response if a sensor's state is set to 'unknown' for non-error reasons (e.g., an empty data list from the API).

This will provide visibility into the exact responses from the Leneda API, which is necessary to find the root cause of the remaining sensor issues.