### PR TITLE
Fix(leneda): Use time-series endpoint for all sensors

### DIFF
--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -32,12 +32,7 @@ class LenedaApiClient:
         url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series"
 
         async with self._session.get(url, headers=headers, params=params) as response:
-            if response.status != 200:
-                return {
-                    "error": True,
-                    "status": response.status,
-                    "text": await response.text(),
-                }
+            response.raise_for_status()
             return await response.json()
 
     async def async_get_aggregated_metering_data(
@@ -59,12 +54,7 @@ class LenedaApiClient:
         url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series/aggregated"
 
         async with self._session.get(url, headers=headers, params=params) as response:
-            if response.status != 200:
-                return {
-                    "error": True,
-                    "status": response.status,
-                    "text": await response.text(),
-                }
+            response.raise_for_status()
             return await response.json()
 
     async def test_credentials(self, metering_point_id: str) -> bool:
@@ -74,9 +64,10 @@ class LenedaApiClient:
         end_date = now
         obis_code = list(OBIS_CODES.keys())[0]
 
-        data = await self.async_get_metering_data(
-            metering_point_id, obis_code, start_date, end_date
-        )
-        if data.get("error"):
+        try:
+            await self.async_get_metering_data(
+                metering_point_id, obis_code, start_date, end_date
+            )
+        except Exception:
             return False
         return True

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -81,45 +81,14 @@ class LenedaSensor(SensorEntity):
         start_date = now - timedelta(hours=25)
         end_date = now
 
-        data = None
         try:
-            # Use time-series for instantaneous values (power)
-            if self._attr_native_unit_of_measurement in ("kW", "kVAR"):
-                data = await self._api_client.async_get_metering_data(
-                    self._metering_point_id, self._obis_code, start_date, end_date
-                )
-                if data and not data.get("error") and data.get("items"):
-                    self._attr_native_value = data["items"][-1]["value"]
-                else:
-                    self._attr_native_value = None
-
-            # Use aggregated for cumulative values (energy, volume)
+            data = await self._api_client.async_get_metering_data(
+                self._metering_point_id, self._obis_code, start_date, end_date
+            )
+            if data and data.get("items"):
+                self._attr_native_value = data["items"][-1]["value"]
             else:
-                data = await self._api_client.async_get_aggregated_metering_data(
-                    self._metering_point_id, self._obis_code, start_date, end_date
-                )
-                if data and not data.get("error") and data.get("aggregatedTimeSeries"):
-                    self._attr_native_value = data["aggregatedTimeSeries"][0]["value"]
-                else:
-                    self._attr_native_value = None
-
-            # Handle API errors or empty data for logging
-            if data and data.get("error"):
-                _LOGGER.warning(
-                    "Leneda API error for sensor %s (OBIS %s): Status %s, Response: %s",
-                    self.name,
-                    self._obis_code,
-                    data.get("status"),
-                    data.get("text"),
-                )
-            elif self._attr_native_value is None:
-                _LOGGER.info(
-                    "Leneda API returned no data for sensor %s (OBIS %s). Full response: %s",
-                    self.name,
-                    self._obis_code,
-                    data,
-                )
-
+                self._attr_native_value = None
         except Exception as e:
             _LOGGER.error("Error fetching data for sensor %s: %s", self.name, e)
             self._attr_native_value = None


### PR DESCRIPTION
This commit provides the final fix for the Leneda sensors reporting 'unknown'. After a thorough investigation involving diagnostic logging, the root cause has been identified and corrected.

The diagnostic logs revealed that the Leneda API's `/time-series/aggregated` endpoint does not return data for the OBIS codes corresponding to cumulative energy (`kWh`) or volume (`m³`) sensors, resulting in an empty `aggregatedTimeSeries` list.

The logs confirmed that the correct approach is to use the `/time-series` endpoint for all sensors defined in this integration. This endpoint correctly returns the latest value for any given OBIS code in its native unit. Previous attempts to fix this were inconclusive due to intermittent network errors and a lack of clarity between unavailable data and actual bugs. The diagnostic logs provided the clear evidence needed to make this final determination.

This change simplifies the sensor update logic in `sensor.py` to exclusively use the `async_get_metering_data` function. All diagnostic code added in previous steps has been removed, and the codebase is now in a clean, production-ready state.