### PR TITLE
feat: Set update interval to 15 minutes and optimize data fetching

### DIFF
--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -20,6 +20,8 @@ from .api import LenedaApiClient
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(minutes=15)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -78,7 +80,7 @@ class LenedaSensor(SensorEntity):
     async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
         now = dt_util.utcnow()
-        start_date = now - timedelta(hours=25)
+        start_date = now - timedelta(hours=1)
         end_date = now
 
         try:


### PR DESCRIPTION
The Leneda sensor integration previously relied on the default Home Assistant update interval and fetched 25 hours of data on each update. This was inefficient and did not provide a configurable update frequency.

This change introduces two improvements:

1.  Sets a `SCAN_INTERVAL` of 15 minutes in `sensor.py` to ensure more frequent and predictable updates, as requested by the user.
2.  Reduces the data fetching window in the `async_update` method from 25 hours to 1 hour. This makes the API calls more efficient and reduces the load on both the Leneda API and the Home Assistant instance.