### PR TITLE
fix(leneda): Ensure latest data point is always used

### DIFF
--- a/custom_components/leneda/coordinator.py
+++ b/custom_components/leneda/coordinator.py
@@ -61,7 +61,13 @@ class LenedaDataUpdateCoordinator(DataUpdateCoordinator):
                         )
                         data[obis_code] = None
                     elif result and result.get("items"):
-                        data[obis_code] = result["items"][-1]["value"]
+                        items = result["items"]
+                        if items:
+                            latest_item = max(items, key=lambda x: x["startedAt"])
+                            data[obis_code] = latest_item["value"]
+                            data[f"{obis_code}_last_updated"] = latest_item["startedAt"]
+                        else:
+                            data[obis_code] = None
                     else:
                         data[obis_code] = None
                 return data

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -82,3 +82,12 @@ class LenedaSensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorEntity)
             and self.coordinator.data is not None
             and self.coordinator.data.get(self._obis_code) is not None
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the state attributes."""
+        if self.coordinator.data:
+            last_updated = self.coordinator.data.get(f"{self._obis_code}_last_updated")
+            if last_updated:
+                return {"last_updated": last_updated}
+        return None


### PR DESCRIPTION
The Leneda API does not guarantee that the time-series data is returned in chronological order. The previous implementation assumed the last item in the list was the newest, which could lead to stale data being displayed.

This change modifies the data processing logic to explicitly find the data point with the most recent 'startedAt' timestamp, ensuring the sensor always reflects the latest available data.

Additionally, the 'startedAt' timestamp is now exposed as a 'last_updated' attribute on the sensor, providing users with visibility into the freshness of the data.