### PR TITLE
fix(leneda): Widen time window for credential testing

### DIFF
--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -72,7 +72,7 @@ class LenedaApiClient:
     async def test_credentials(self, metering_point_id: str) -> bool:
         """Test credentials against the Leneda API."""
         now = dt_util.utcnow()
-        start_date = now - timedelta(hours=1)
+        start_date = now - timedelta(hours=25)
         end_date = now
         obis_code = list(OBIS_CODES.keys())[0]
 


### PR DESCRIPTION
The `test_credentials` function used a 1-hour time window to check for data. This could cause the setup to fail with a "no_data" error if the meter hadn't reported any data in that short period.

This change increases the time window to 25 hours, making the credential check more robust and less likely to fail due to a lack of very recent data.