### PR TITLE
feat(leneda): Full integration overhaul and bug fixes

### DIFF
--- a/custom_components/leneda/coordinator.py
+++ b/custom_components/leneda/coordinator.py
@@ -65,7 +65,7 @@ class LenedaDataUpdateCoordinator(DataUpdateCoordinator):
                         if items:
                             latest_item = max(items, key=lambda x: x["startedAt"])
                             data[obis_code] = latest_item["value"]
-                            data[f"{obis_code}_last_updated"] = latest_item["startedAt"]
+                            data[f"{obis_code}_data_timestamp"] = latest_item["startedAt"]
                         else:
                             data[obis_code] = None
                     else:

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -57,6 +57,12 @@ class LenedaSensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorEntity)
         elif details["unit"] == "kWh":
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        elif details["unit"] == "kVAR":
+            self._attr_device_class = SensorDeviceClass.REACTIVE_POWER
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+        elif details["unit"] in ("m³", "Nm³"):
+            self._attr_device_class = SensorDeviceClass.GAS
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
         self._attr_icon = "mdi:flash"
         self._attr_device_info = DeviceInfo(
@@ -87,7 +93,7 @@ class LenedaSensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorEntity)
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the state attributes."""
         if self.coordinator.data:
-            last_updated = self.coordinator.data.get(f"{self._obis_code}_last_updated")
-            if last_updated:
-                return {"last_updated": last_updated}
+            data_timestamp = self.coordinator.data.get(f"{self._obis_code}_data_timestamp")
+            if data_timestamp:
+                return {"data_timestamp": data_timestamp}
         return None


### PR DESCRIPTION
This commit provides a comprehensive update to the Leneda integration, addressing multiple issues reported by the user.

- **Robust Data Parsing**: The coordinator now correctly finds the latest data point by its timestamp (`startedAt`) instead of assuming the API response is sorted.
- **Complete Sensor Support**: All 17 OBIS codes from the Leneda API documentation are now included in `const.py`, allowing all sensors to be created.
- **Correct Sensor Classification**: `sensor.py` has been enhanced to correctly assign `device_class` and `state_class` for all units (`kW`, `kWh`, `kVAR`, `m³`, `Nm³`).
- **Clearer Timestamps**: The timestamp of the data from the Leneda API is now exposed as a `data_timestamp` attribute on sensors, avoiding confusion with Home Assistant's internal `last_updated` property.
- **Improved Setup**: The credential test now uses a 25-hour window to check for data, making the initial setup process more reliable and preventing `no_data` errors.