### PR TITLE
Fix Leneda integration issues

### DIFF
--- a/custom_components/leneda/coordinator.py
+++ b/custom_components/leneda/coordinator.py
@@ -37,8 +37,8 @@ class LenedaDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from the Leneda API concurrently."""
         _LOGGER.debug("Fetching data from Leneda API")
         now = dt_util.utcnow()
-        # Use a 25-hour window to ensure we get data even if it's not recent
-        start_date = now - timedelta(hours=25)
+        # Use a 1-hour window to ensure we get the latest data.
+        start_date = now - timedelta(hours=1)
         end_date = now
 
         try:

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -67,7 +67,7 @@ class LenedaSensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorEntity)
         self._attr_icon = "mdi:flash"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, metering_point_id)},
-            name=f"Leneda ({metering_point_id})",
+            name=f"Leneda (...{metering_point_id[-4:]})",
             manufacturer="Leneda",
             model="Metering Point",
             sw_version=coordinator.version,


### PR DESCRIPTION
This commit addresses three issues in the Leneda integration:

1.  **"no_data" error on login:** The `test_credentials` function was raising a `NoDataError` even with valid credentials if the API returned no data for the queried period. The logic is now more lenient and only requires a successful API response (HTTP 200) to validate credentials. Error handling for authentication failures (401/403) has also been improved.

2.  **Infrequent updates:** The integration was fetching data for a 25-hour window every 15 minutes, which caused updates to appear only once a day. The data fetching window has been reduced to 1 hour, ensuring that the latest data is always retrieved.

3.  **Long friendly names:** The device name now uses the last 4 digits of the metering point ID, making it shorter and more readable, as requested.