### PR TITLE
feat: Add hourly and 15-minute sensors and fix daily calculation

### DIFF
--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -53,6 +53,7 @@ class LenedaApiClient:
         obis_code: str,
         start_date: datetime,
         end_date: datetime,
+        aggregation_level: str = "Infinite",
     ) -> dict:
         """Fetch aggregated metering data from the Leneda API."""
         headers = {"X-API-KEY": self._api_key, "X-ENERGY-ID": self._energy_id}
@@ -60,7 +61,7 @@ class LenedaApiClient:
             "startDate": start_date.strftime("%Y-%m-%d"),
             "endDate": end_date.strftime("%Y-%m-%d"),
             "obisCode": obis_code,
-            "aggregationLevel": "Infinite",
+            "aggregationLevel": aggregation_level,
             "transformationMode": "Accumulation",
         }
         url = f"{API_BASE_URL}/api/metering-points/{metering_point_id}/time-series/aggregated"

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -44,6 +44,10 @@ async def async_setup_entry(
         "last_week_production": "Last Week's Production",
         "previous_month_consumption": "Previous Month's Consumption",
         "previous_month_production": "Previous Month's Production",
+        "hourly_consumption": "Hourly Consumption",
+        "hourly_production": "Hourly Production",
+        "quarter_hourly_consumption": "15-Minute Consumption",
+        "quarter_hourly_production": "15-Minute Production",
     }
     for sensor_key, name in energy_sensors_to_add.items():
         sensors.append(


### PR DESCRIPTION
This commit introduces several new features and fixes to the Leneda integration based on user feedback:

1.  **Add Hourly and 15-Minute Sensors:** New sensors have been added to provide more granular energy data:
    - "Hourly Consumption" and "Hourly Production" show the total energy for the last completed hour.
    - "15-Minute Consumption" and "15-Minute Production" show the calculated energy for the latest 15-minute interval.

2.  **Fix Daily Consumption/Production Calculation:** The "Daily Consumption" and "Daily Production" sensors now correctly show a running total for the current, incomplete day. This is achieved by fetching all available hourly data for the current day and summing it up.

3.  **Refactor Coordinator for New Data:**
    - The `DataUpdateCoordinator` has been updated to fetch data from the Leneda API's hourly aggregation endpoint.
    - The coordinator now calculates the running daily total, the last hour's total, and the 15-minute energy interval from the various API responses.
    - The API client was also updated to support different aggregation levels.