### PR TITLE
feat: Finalize Leneda integration with sensor ordering and bugfixes

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -12,7 +12,13 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from .api import LenedaApiClient
-from .const import CONF_API_KEY, CONF_ENERGY_ID, CONF_METERING_POINT_ID, DOMAIN
+from .const import (
+    CONF_API_KEY,
+    CONF_ENERGY_ID,
+    CONF_METERING_POINT_ID,
+    CONF_METER_TYPE,
+    DOMAIN,
+)
 from .coordinator import LenedaDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -24,11 +30,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_client = LenedaApiClient(
         session,
         entry.data[CONF_API_KEY],
-        entry.data[CONF_ENERGY_ID]
+        entry.data[CONF_ENERGY_ID],
     )
-    metering_point_id = entry.data[CONF_METERING_POINT_ID]
 
-    coordinator = LenedaDataUpdateCoordinator(hass, api_client, metering_point_id)
+    coordinator = LenedaDataUpdateCoordinator(
+        hass,
+        api_client=api_client,
+        metering_point_id=entry.data[CONF_METERING_POINT_ID],
+        meter_type=entry.data[CONF_METER_TYPE],
+    )
 
     manifest_path = Path(__file__).parent / "manifest.json"
     with manifest_path.open() as manifest_file:

--- a/custom_components/leneda/api.py
+++ b/custom_components/leneda/api.py
@@ -18,7 +18,7 @@ class NoDataError(LenedaApiError):
 
 from homeassistant.util import dt as dt_util
 
-from .const import API_BASE_URL, OBIS_CODES
+from .const import API_BASE_URL
 
 
 class LenedaApiClient:
@@ -79,44 +79,50 @@ class LenedaApiClient:
             _LOGGER.debug("Leneda aggregated data response: %s", json_response)
             return json_response
 
-    async def test_credentials(self, metering_point_id: str) -> bool:
-        """Test credentials against the Leneda API."""
+    async def async_determine_meter_types(self, metering_point_id: str) -> list[str]:
+        """Determine all supported meter types by checking which OBIS codes return data."""
         now = dt_util.utcnow()
-        start_date = now - timedelta(hours=25)
-        end_date = now
+        start_date = now - timedelta(days=7)
+        supported_types = []
+
+        electricity_code = "1-1:1.29.0"
+        gas_code = "7-1:99.23.15"
 
         try:
-            live_tasks = [
-                self.async_get_metering_data(
-                    metering_point_id, obis_code, start_date, end_date
-                )
-                for obis_code in OBIS_CODES
-            ]
-            aggregated_task = self.async_get_aggregated_metering_data(
-                metering_point_id, "1-1:1.29.0", start_date, end_date
+            # Probe for electricity
+            _LOGGER.debug("Probing for electricity data for meter %s", metering_point_id)
+            electricity_data = await self.async_get_metering_data(
+                metering_point_id, electricity_code, start_date, now
             )
+            if electricity_data and electricity_data.get("items"):
+                _LOGGER.info("Detected ELECTRICITY capability for meter %s", metering_point_id)
+                supported_types.append("electricity")
 
-            tasks = live_tasks + [aggregated_task]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+            # Probe for gas
+            _LOGGER.debug("Probing for gas data for meter %s", metering_point_id)
+            gas_data = await self.async_get_metering_data(
+                metering_point_id, gas_code, start_date, now
+            )
+            if gas_data and gas_data.get("items"):
+                _LOGGER.info("Detected GAS capability for meter %s", metering_point_id)
+                supported_types.append("gas")
 
-            # Check for any authentication errors first. If any call fails with 401/403,
-            # it's an immediate failure, regardless of other calls.
-            for r in results:
-                if isinstance(r, aiohttp.ClientResponseError) and r.status in (401, 403):
-                    raise InvalidAuth from r
-
-            # If we passed the auth check, ensure at least one call was successful.
-            has_successful_call = any(isinstance(r, dict) for r in results)
-
-            if not has_successful_call:
-                # If no calls were successful, but we know there were no auth errors,
-                # it's a general data or API issue.
-                raise NoDataError("No successful API calls, but no authentication errors detected.")
-
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403):
+                raise InvalidAuth from err
+            # For other errors, we might have partial results, so we don't re-raise yet
+            _LOGGER.error("API error while probing meter type: %s", err)
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise LenedaApiError from err
+            _LOGGER.error("Connection error while probing meter type: %s", err)
 
-        return True
+        if not supported_types:
+            _LOGGER.warning(
+                "Could not determine any supported meter type for %s.",
+                metering_point_id,
+            )
+            raise NoDataError("Could not determine meter type.")
+
+        return supported_types
 
     async def async_create_metering_data_access_request(
         self,

--- a/custom_components/leneda/const.py
+++ b/custom_components/leneda/const.py
@@ -4,26 +4,37 @@ DOMAIN = "leneda"
 
 API_BASE_URL = "https://api.leneda.eu"
 
+# Configuration keys
 CONF_API_KEY = "api_key"
 CONF_ENERGY_ID = "energy_id"
 CONF_METERING_POINT_ID = "metering_point_id"
+CONF_METER_TYPE = "meter_types" # Note: Storing a list of types
 
-OBIS_CODES = {
-    "1-1:1.29.0": {"name": "Measured Active Consumption", "unit": "kW"},
-    "1-1:2.29.0": {"name": "Measured Active Production", "unit": "kW"},
-    "1-1:3.29.0": {"name": "Measured Reactive Consumption", "unit": "kVAR"},
-    "1-1:4.29.0": {"name": "Measured Reactive Production", "unit": "kVAR"},
-    "1-65:1.29.1": {"name": "Consumption Covered by Production (Layer 1)", "unit": "kW"},
-    "1-65:1.29.3": {"name": "Consumption Covered by Production (Layer 2)", "unit": "kW"},
-    "1-65:1.29.2": {"name": "Consumption Covered by Production (Layer 3)", "unit": "kW"},
-    "1-65:1.29.4": {"name": "Consumption Covered by Production (Layer 4)", "unit": "kW"},
-    "1-65:1.29.9": {"name": "Remaining Consumption After Sharing", "unit": "kW"},
-    "1-65:2.29.1": {"name": "Production Shared (Layer 1)", "unit": "kW"},
-    "1-65:2.29.3": {"name": "Production Shared (Layer 2)", "unit": "kW"},
-    "1-65:2.29.2": {"name": "Production Shared (Layer 3)", "unit": "kW"},
-    "1-65:2.29.4": {"name": "Production Shared (Layer 4)", "unit": "kW"},
-    "1-65:2.29.9": {"name": "Remaining Production After Sharing", "unit": "kW"},
-    "7-1:99.23.15": {"name": "Measured Consumed Volume", "unit": "m³"},
-    "7-1:99.23.17": {"name": "Measured Consumed Standard Volume", "unit": "Nm³"},
-    "7-20:99.33.17": {"name": "Measured Consumed Energy", "unit": "kWh"},
+# Meter types
+METER_TYPE_ELECTRICITY = "electricity"
+METER_TYPE_GAS = "gas"
+
+ELECTRICITY_OBIS_CODES = {
+    "1-1:1.29.0": {"name": "01 - Measured Active Consumption", "unit": "kW"},
+    "1-1:2.29.0": {"name": "02 - Measured Active Production", "unit": "kW"},
+    "1-1:3.29.0": {"name": "03 - Measured Reactive Consumption", "unit": "kVAR"},
+    "1-1:4.29.0": {"name": "04 - Measured Reactive Production", "unit": "kVAR"},
+    "1-65:1.29.1": {"name": "05 - Consumption Covered by Production (Layer 1)", "unit": "kW"},
+    "1-65:1.29.3": {"name": "06 - Consumption Covered by Production (Layer 2)", "unit": "kW"},
+    "1-65:1.29.2": {"name": "07 - Consumption Covered by Production (Layer 3)", "unit": "kW"},
+    "1-65:1.29.4": {"name": "08 - Consumption Covered by Production (Layer 4)", "unit": "kW"},
+    "1-65:1.29.9": {"name": "09 - Remaining Consumption After Sharing", "unit": "kW"},
+    "1-65:2.29.1": {"name": "10 - Production Shared (Layer 1)", "unit": "kW"},
+    "1-65:2.29.3": {"name": "11 - Production Shared (Layer 2)", "unit": "kW"},
+    "1-65:2.29.2": {"name": "12 - Production Shared (Layer 3)", "unit": "kW"},
+    "1-65:2.29.4": {"name": "13 - Production Shared (Layer 4)", "unit": "kW"},
+    "1-65:2.29.9": {"name": "14 - Remaining Production After Sharing", "unit": "kW"},
 }
+
+GAS_OBIS_CODES = {
+    "7-1:99.23.15": {"name": "20 - GAS - Measured Consumed Volume", "unit": "m³"},
+    "7-1:99.23.17": {"name": "21 - GAS - Measured Consumed Standard Volume", "unit": "Nm³"},
+    "7-20:99.33.17": {"name": "22 - GAS - Measured Consumed Energy", "unit": "kWh"},
+}
+
+ALL_OBIS_CODES = {**ELECTRICITY_OBIS_CODES, **GAS_OBIS_CODES}

--- a/custom_components/leneda/coordinator.py
+++ b/custom_components/leneda/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the Leneda integration."""
 from __future__ import annotations
+from typing import Any
 
 import asyncio
 import async_timeout
@@ -14,7 +15,13 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from .api import LenedaApiClient
-from .const import DOMAIN, OBIS_CODES
+from .const import (
+    DOMAIN,
+    METER_TYPE_ELECTRICITY,
+    METER_TYPE_GAS,
+    ELECTRICITY_OBIS_CODES,
+    GAS_OBIS_CODES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,201 +29,190 @@ _LOGGER = logging.getLogger(__name__)
 class LenedaDataUpdateCoordinator(DataUpdateCoordinator):
     """A coordinator to fetch data from the Leneda API."""
 
-    def __init__(self, hass: HomeAssistant, api_client: LenedaApiClient, metering_point_id: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_client: LenedaApiClient,
+        metering_point_id: str,
+        meter_types: list[str],
+    ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
-            name=DOMAIN,
+            name=f"{DOMAIN}_{metering_point_id}",
             update_interval=timedelta(minutes=15),
         )
         self.api_client = api_client
         self.metering_point_id = metering_point_id
+        self.meter_types = meter_types
+
+        # Build the list of all OBIS codes to fetch based on supported meter types
+        self.obis_codes_to_fetch: dict[str, Any] = {}
+        if METER_TYPE_ELECTRICITY in self.meter_types:
+            self.obis_codes_to_fetch.update(ELECTRICITY_OBIS_CODES)
+        if METER_TYPE_GAS in self.meter_types:
+            self.obis_codes_to_fetch.update(GAS_OBIS_CODES)
+
+        _LOGGER.info(
+            "Leneda coordinator initialized for meter %s with types %s, fetching %d OBIS codes",
+            self.metering_point_id,
+            self.meter_types,
+            len(self.obis_codes_to_fetch),
+        )
+
 
     async def _async_update_data(self) -> dict[str, float | None]:
         """Fetch data from the Leneda API concurrently."""
-        _LOGGER.debug("--- Starting Leneda Data Update ---")
+        _LOGGER.debug("--- Starting Leneda Data Update for %s ---", self.metering_point_id)
         now = dt_util.utcnow()
 
         try:
             async with async_timeout.timeout(30):
-                # Define date ranges
+                # Define date ranges used across multiple API calls
                 today_start_dt = now.replace(hour=0, minute=0, second=0, microsecond=0)
                 live_data_start_dt = now - timedelta(minutes=60) # Fetch last 60 mins for live data
-                month_start_dt = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-                week_start_dt = today_start_dt - timedelta(days=now.weekday())
-                yesterday_start_dt = today_start_dt - timedelta(days=1)
-                yesterday_end_dt = today_start_dt - timedelta(microseconds=1)
-                last_week_start_dt = week_start_dt - timedelta(weeks=1)
-                last_week_end_dt = week_start_dt - timedelta(microseconds=1)
-                first_day_of_current_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-                end_of_last_month = first_day_of_current_month - timedelta(microseconds=1)
-                start_of_last_month = end_of_last_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
-                CONSUMPTION_CODE = "1-1:1.29.0"
-                PRODUCTION_CODE = "1-1:2.29.0"
-
-                # Tasks for live power data (OBIS codes)
-                _LOGGER.debug("Setting up tasks for live power data...")
-                live_power_tasks = [
+                # --- Tasks for live power data (all relevant OBIS codes) ---
+                # This fetches the latest instantaneous values for all supported meter types.
+                _LOGGER.debug("Setting up tasks for live data for meter %s", self.metering_point_id)
+                live_data_tasks = [
                     self.api_client.async_get_metering_data(
                         self.metering_point_id, obis_code, live_data_start_dt, now
-                    ) for obis_code in OBIS_CODES
+                    ) for obis_code in self.obis_codes_to_fetch
                 ]
 
-                # Tasks for 15-minute raw data (for energy calculation)
-                _LOGGER.debug("Setting up tasks for 15-minute raw data...")
-                quarter_hour_start_dt = now - timedelta(minutes=15)
-                quarter_hour_tasks = [
-                    self.api_client.async_get_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, quarter_hour_start_dt, now
-                    ),
-                    self.api_client.async_get_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, quarter_hour_start_dt, now
-                    ),
-                ]
+                all_tasks = live_data_tasks
+                quarter_hour_tasks = []
+                aggregated_tasks = []
 
-                # Tasks for aggregated data
-                _LOGGER.debug("Setting up tasks for aggregated data...")
-                aggregated_tasks = [
-                    # Hourly (Current hour)
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, today_start_dt, now, aggregation_level="Hour"
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, today_start_dt, now, aggregation_level="Hour"
-                    ),
-                    # Daily
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, today_start_dt, now
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, today_start_dt, now
-                    ),
-                    # Weekly
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, week_start_dt, now
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, week_start_dt, now
-                    ),
-                    # Monthly
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, month_start_dt, now
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, month_start_dt, now
-                    ),
-                    # Yesterday
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, yesterday_start_dt, yesterday_end_dt
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, yesterday_start_dt, yesterday_end_dt
-                    ),
-                    # Last Week
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, last_week_start_dt, last_week_end_dt
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, last_week_start_dt, last_week_end_dt
-                    ),
-                    # Previous Month
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, CONSUMPTION_CODE, start_of_last_month, end_of_last_month
-                    ),
-                    self.api_client.async_get_aggregated_metering_data(
-                        self.metering_point_id, PRODUCTION_CODE, start_of_last_month, end_of_last_month
-                    ),
-                ]
-                quarter_hour_keys = [
-                    "c_01_quarter_hourly_consumption", "p_01_quarter_hourly_production"
-                ]
-                
-                aggregated_keys = [
-                    "c_02_hourly_consumption", "p_02_hourly_production",
-                    "c_03_daily_consumption", "p_03_daily_production",
-                    "c_05_weekly_consumption", "p_05_weekly_production",
-                    "c_07_monthly_consumption", "p_07_monthly_production",
-                    "c_04_yesterday_consumption", "p_04_yesterday_production",
-                    "c_06_last_week_consumption", "p_06_last_week_production",
-                    "c_08_previous_month_consumption", "p_08_previous_month_production",
-                ]
+                # --- Electricity-specific tasks ---
+                # These tasks for aggregated energy (kWh) are only relevant for electricity meters.
+                if METER_TYPE_ELECTRICITY in self.meter_types:
+                    _LOGGER.debug("Meter %s supports electricity, adding electricity-specific tasks", self.metering_point_id)
 
-                _LOGGER.debug("Gathering all API tasks...")
-                all_tasks = live_power_tasks + quarter_hour_tasks + aggregated_tasks
+                    # Define date ranges for electricity-specific aggregated tasks
+                    month_start_dt = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+                    week_start_dt = today_start_dt - timedelta(days=now.weekday())
+                    yesterday_start_dt = today_start_dt - timedelta(days=1)
+                    yesterday_end_dt = today_start_dt - timedelta(microseconds=1)
+                    last_week_start_dt = week_start_dt - timedelta(weeks=1)
+                    last_week_end_dt = week_start_dt - timedelta(microseconds=1)
+                    first_day_of_current_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+                    end_of_last_month = first_day_of_current_month - timedelta(microseconds=1)
+                    start_of_last_month = end_of_last_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+                    CONSUMPTION_CODE = "1-1:1.29.0"
+                    PRODUCTION_CODE = "1-1:2.29.0"
+
+                    # Tasks for 15-minute raw data (for energy calculation)
+                    _LOGGER.debug("Setting up tasks for 15-minute raw data...")
+                    quarter_hour_start_dt = now - timedelta(minutes=15)
+                    quarter_hour_tasks = [
+                        self.api_client.async_get_metering_data(
+                            self.metering_point_id, CONSUMPTION_CODE, quarter_hour_start_dt, now
+                        ),
+                        self.api_client.async_get_metering_data(
+                            self.metering_point_id, PRODUCTION_CODE, quarter_hour_start_dt, now
+                        ),
+                    ]
+
+                    # Tasks for aggregated data (daily, weekly, monthly, etc.)
+                    _LOGGER.debug("Setting up tasks for aggregated data...")
+                    aggregated_tasks = [
+                        # Hourly (Current hour)
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, today_start_dt, now, "Hour"),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, today_start_dt, now, "Hour"),
+                        # Daily
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, today_start_dt, now),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, today_start_dt, now),
+                        # Weekly
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, week_start_dt, now),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, week_start_dt, now),
+                        # Monthly
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, month_start_dt, now),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, month_start_dt, now),
+                        # Yesterday
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, yesterday_start_dt, yesterday_end_dt),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, yesterday_start_dt, yesterday_end_dt),
+                        # Last Week
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, last_week_start_dt, last_week_end_dt),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, last_week_start_dt, last_week_end_dt),
+                        # Previous Month
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, CONSUMPTION_CODE, start_of_last_month, end_of_last_month),
+                        self.api_client.async_get_aggregated_metering_data(self.metering_point_id, PRODUCTION_CODE, start_of_last_month, end_of_last_month),
+                    ]
+                    all_tasks.extend(quarter_hour_tasks)
+                    all_tasks.extend(aggregated_tasks)
+
+                _LOGGER.debug("Gathering all %d API tasks for meter %s", len(all_tasks), self.metering_point_id)
                 results = await asyncio.gather(*all_tasks, return_exceptions=True)
                 _LOGGER.debug("All API tasks gathered.")
 
-                live_power_results = results[:len(live_power_tasks)]
-                quarter_hour_results = results[len(live_power_tasks):len(live_power_tasks) + len(quarter_hour_tasks)]
-                aggregated_results = results[len(live_power_tasks) + len(quarter_hour_tasks):]
+                # Split the results back into their respective categories
+                live_power_results = results[:len(live_data_tasks)]
+                quarter_hour_results = results[len(live_data_tasks):len(live_data_tasks) + len(quarter_hour_tasks)]
+                aggregated_results = results[len(live_data_tasks) + len(quarter_hour_tasks):]
 
                 data = self.data.copy() if self.data else {}
 
-                # Ensure keys exist before processing, setting a default
-                data.setdefault("c_01_quarter_hourly_consumption", 0.0)
-                data.setdefault("p_01_quarter_hourly_production", 0.0)
-
-                _LOGGER.debug("Processing live power results...")
-                # Process live power results
-                for obis_code, result in zip(OBIS_CODES.keys(), live_power_results):
+                # Process the results for live data
+                _LOGGER.debug("Processing live data results...")
+                for obis_code, result in zip(self.obis_codes_to_fetch.keys(), live_power_results):
                     if isinstance(result, dict) and result.get("items"):
-                        _LOGGER.debug(f"Processing live data for {obis_code}, result: {result}")
                         latest_item = max(result["items"], key=lambda x: dt_util.parse_datetime(x["startedAt"]))
-                        value = latest_item["value"]
-                        data[obis_code] = value
+                        data[obis_code] = latest_item["value"]
                         data[f"{obis_code}_data_timestamp"] = latest_item["startedAt"]
-                        _LOGGER.debug(f"Latest item for {obis_code}: {latest_item}")
                     elif isinstance(result, Exception):
                         _LOGGER.error("Error fetching live data for %s: %s", obis_code, result)
                     else:
                         _LOGGER.warning("No items found for live data obis_code %s. Response: %s", obis_code, result)
 
-                _LOGGER.debug("Processing 15-minute results...")
-                # Process 15-minute results for energy calculation (kW * 0.25h = kWh)
-                quarter_hour_codes = [CONSUMPTION_CODE, PRODUCTION_CODE]
-                for key, code, result in zip(quarter_hour_keys, quarter_hour_codes, quarter_hour_results):
-                    if isinstance(result, dict) and result.get("items"):
-                        _LOGGER.debug(f"Processing 15-min data for {key}, result: {result}")
-                        # Sum all 15-minute intervals and convert to kWh
-                        total_kwh = sum(item["value"] * 0.25 for item in result["items"])
-                        data[key] = total_kwh
-                        _LOGGER.debug(f"15-minute energy for {key}: {total_kwh} kWh")
-                    elif isinstance(result, Exception):
-                        _LOGGER.error("Error fetching 15-minute data for %s: %s", key, result)
-                        data[key] = 0.0
-                    else:
-                        _LOGGER.warning("No items found for 15-minute data %s. Response: %s", key, result)
-                        data[key] = 0.0
+                # --- Process Electricity-specific results ---
+                if METER_TYPE_ELECTRICITY in self.meter_types:
+                    quarter_hour_keys = ["c_01_quarter_hourly_consumption", "p_01_quarter_hourly_production"]
+                    aggregated_keys = [
+                        "c_02_hourly_consumption", "p_02_hourly_production",
+                        "c_03_daily_consumption", "p_03_daily_production",
+                        "c_05_weekly_consumption", "p_05_weekly_production",
+                        "c_07_monthly_consumption", "p_07_monthly_production",
+                        "c_04_yesterday_consumption", "p_04_yesterday_production",
+                        "c_06_last_week_consumption", "p_06_last_week_production",
+                        "c_08_previous_month_consumption", "p_08_previous_month_production",
+                    ]
 
-
-                _LOGGER.debug("Processing aggregated results...")
-                # Process aggregated results
-                for key, result in zip(aggregated_keys, aggregated_results):
-                    if isinstance(result, dict):
-                        _LOGGER.debug(f"Processing aggregated data for {key}, result: {result}")
-                        series = result.get("aggregatedTimeSeries")
-                        if series:
-                            if key.startswith("c_02_") or key.startswith("p_02_"): # Hourly
-                                data[key] = series[-1].get("value") if series else 0.0
-                                _LOGGER.debug(f"Processed hourly data for {key}: {data[key]}")
-                            else: # Other aggregated
-                                data[key] = series[0].get("value") if series else 0.0
-                                _LOGGER.debug(f"Processed aggregated data for {key}: {data[key]}")
+                    # Process 15-minute results (convert kW to kWh)
+                    _LOGGER.debug("Processing 15-minute results...")
+                    quarter_hour_codes = [CONSUMPTION_CODE, PRODUCTION_CODE]
+                    for key, code, result in zip(quarter_hour_keys, quarter_hour_codes, quarter_hour_results):
+                        if isinstance(result, dict) and result.get("items"):
+                            total_kwh = sum(item["value"] * 0.25 for item in result["items"])
+                            data[key] = total_kwh
+                        elif isinstance(result, Exception):
+                            _LOGGER.error("Error fetching 15-minute data for %s: %s", key, result)
                         else:
-                            data[key] = 0.0
-                            _LOGGER.debug(f"No aggregated time series for {key}, setting value to 0.0")
-                    elif isinstance(result, Exception):
-                        _LOGGER.error("Error fetching aggregated data for %s: %s", key, result)
-                        if key not in data: data[key] = None
-                    else:
-                        _LOGGER.warning("Unexpected result type for aggregated data %s. Response: %s", key, result)
-                        if key not in data: data[key] = None
+                            _LOGGER.warning("No items found for 15-minute data %s. Response: %s", key, result)
 
-                _LOGGER.debug("--- Leneda Data Update Finished ---")
-                _LOGGER.debug("Final coordinated data: %s", data)
+                    # Process aggregated results
+                    _LOGGER.debug("Processing aggregated results...")
+                    for key, result in zip(aggregated_keys, aggregated_results):
+                        if isinstance(result, dict):
+                            series = result.get("aggregatedTimeSeries")
+                            if series:
+                                value = series[-1].get("value") if key.startswith(("c_02_", "p_02_")) else series[0].get("value")
+                                if value is not None:
+                                    data[key] = value
+                                else:
+                                    _LOGGER.warning(f"Aggregated data for {key} is null, retaining previous value.")
+                            else:
+                                _LOGGER.warning(f"No aggregated time series for {key}, retaining previous value.")
+                        elif isinstance(result, Exception):
+                            _LOGGER.error("Error fetching aggregated data for %s: %s", key, result)
+                        else:
+                            _LOGGER.warning("Unexpected result type for aggregated data %s. Response: %s", key, result)
+
+                _LOGGER.debug("--- Leneda Data Update Finished for %s ---", self.metering_point_id)
                 return data
         except (asyncio.TimeoutError, Exception) as err:
-            _LOGGER.error("Fatal error during Leneda data fetch: %s", err, exc_info=True)
+            _LOGGER.error("Fatal error during Leneda data fetch for %s: %s", self.metering_point_id, err, exc_info=True)
             raise UpdateFailed(f"Error communicating with API: {err}") from err


### PR DESCRIPTION
This commit applies the final set of enhancements and bugfixes to the Leneda integration based on user feedback.

Key changes:
1.  **Sensor Ordering:** All sensor names are now prefixed with a number (e.g., "01 - ...", "20 - GAS - ...") to provide a clear and logical grouping in the Home Assistant UI, with gas sensors sorted separately from electricity sensors.

2.  **Dual-Meter Support:** The integration now correctly handles meters that provide both electricity and gas data. It auto-detects all supported capabilities for a single metering point during setup and creates a unified device.

3.  **Robust Data Handling:** Fixed a critical bug where sensors would drop to 0.00 kWh if the API returned no new data. The coordinator now correctly retains the last known value.

4.  **Gas Sensor Clarity:** All gas-specific sensors are prefixed with "GAS - " for improved clarity.

5.  **Efficient Fetching:** The data coordinator now only schedules API calls for data types relevant to the detected meter capabilities.

6.  **Improved Configuration:** The setup process prevents duplicate metering points and generates more descriptive device titles.

7.  **Code Quality:** Restored and added comments to the data coordinator to improve maintainability.