### PR TITLE
chore: Change update interval to 1 hour

### DIFF
--- a/custom_components/leneda/coordinator.py
+++ b/custom_components/leneda/coordinator.py
@@ -41,7 +41,7 @@ class LenedaDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=15),
+            update_interval=timedelta(hours=1),
         )
         self.api_client = api_client
         self.metering_point_id = metering_point_id


### PR DESCRIPTION
This commit changes the integration's update interval from 15 minutes to 1 hour. This is a more reasonable default for an integration that fetches daily data, and it reduces the number of API calls made to the Leneda server, making the integration friendlier to the service.