### PR TITLE
feat: Add power over reference sensor and more historicals

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,37 @@ Configure the Energy Dashboard:
 - **Solar Panels**:
   - Solar production: `sensor.daily_solar_production`
 
+### Tracking Power Usage Over a Reference Limit
+For users on contracts with a demand charge (e.g., you pay extra if you exceed 12 kW of power), this integration can calculate the total energy consumed above that limit.
+
+**Step 1: Create an `input_number` Helper**
+This helper will store your reference power value.
+1. Go to **Settings → Devices & Services → Helpers**.
+2. Click **+ Create Helper** and choose **Number**.
+3. Name it (e.g., "Reference Power Limit").
+4. Set the **Unit of measurement** to **kW**.
+5. Set the **Mode** to **Box** so you can type a value.
+6. Click **Submit**. Note the entity ID (e.g., `input_number.reference_power_limit`).
+
+**Step 2: Configure the Integration**
+When you add or reconfigure the Leneda integration, you will see an optional field for "Reference Power Entity". Select the `input_number` helper you just created.
+
+**Step 3: Use the New Sensor**
+The integration will create a new sensor:
+- `sensor.leneda_..._yesterdays_power_usage_over_reference`
+
+This sensor shows the total energy (in kWh) consumed above your reference value on the previous day.
+
+**Step 4 (Optional): Track Monthly Overage**
+To get a running total for the month, create a `utility_meter` helper:
+````yaml
+# configuration.yaml
+utility_meter:
+  monthly_power_overage:
+    source: sensor.leneda_...XXXX..._yesterdays_power_usage_over_reference
+    cycle: monthly
+````
+
 ---
 
 ### Energy Billing & Auto-Consumption Calculations
@@ -244,6 +275,13 @@ These sensors provide detailed data about your participation in an energy commun
 - Last Month's Remaining Consumption
 - Last Month's Production Shared (L1-L4)
 - Last Month's Remaining Production
+
+### Power Usage Over Reference
+This sensor is only created if you configure the feature.
+
+| Entity ID Suffix | UI Name | Description |
+|------------------|---------|-------------|
+| `..._yesterdays_power_usage_over_reference` | Yesterday's Power Usage Over Reference | Total energy (kWh) consumed above the configured reference power during the previous day. |
 
 ---
 

--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     metering_point_id = entry.data[CONF_METERING_POINT_ID]
 
-    coordinator = LenedaDataUpdateCoordinator(hass, api_client, metering_point_id)
+    coordinator = LenedaDataUpdateCoordinator(hass, api_client, metering_point_id, entry)
 
     manifest_path = Path(__file__).parent / "manifest.json"
     with manifest_path.open() as manifest_file:

--- a/custom_components/leneda/config_flow.py
+++ b/custom_components/leneda/config_flow.py
@@ -3,12 +3,14 @@ import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import selector as sel
 
 from .api import InvalidAuth, LenedaApiClient, LenedaApiError, NoDataError
 from .const import (
     CONF_API_KEY,
     CONF_ENERGY_ID,
     CONF_METERING_POINT_ID,
+    CONF_REFERENCE_POWER_ENTITY,
     DOMAIN,
 )
 
@@ -49,6 +51,9 @@ class LenedaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_METERING_POINT_ID): str,
                     vol.Required(CONF_API_KEY): str,
                     vol.Required(CONF_ENERGY_ID): str,
+                    vol.Optional(CONF_REFERENCE_POWER_ENTITY): sel.EntitySelector(
+                        sel.EntitySelectorConfig(domain="input_number"),
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/leneda/const.py
+++ b/custom_components/leneda/const.py
@@ -7,6 +7,7 @@ API_BASE_URL = "https://api.leneda.eu"
 CONF_API_KEY = "api_key"
 CONF_ENERGY_ID = "energy_id"
 CONF_METERING_POINT_ID = "metering_point_id"
+CONF_REFERENCE_POWER_ENTITY = "reference_power_entity"
 
 OBIS_CODES = {
     "1-1:1.29.0": {"name": "Measured Active Consumption", "unit": "kW", "service_type": "electricity"},

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -106,6 +106,12 @@ async def async_setup_entry(
         ("s_p_rem_last_month", "49 - Last Month's Remaining Production", "energy"),
     ]
 
+    # Conditionally add the power usage over reference sensor
+    if coordinator.reference_power_entity:
+        all_sensors_ordered.append(
+            ("yesterdays_power_usage_over_reference", "50 - Yesterday's Power Usage Over Reference", "energy")
+        )
+
     sensors = []
     _LOGGER.debug("Creating sensors in the following order:")
     for key, name, sensor_type in all_sensors_ordered:


### PR DESCRIPTION
This commit introduces a major new feature to track power usage over a configurable reference limit, and also adds a significant number of new historical sensors as requested.

The key changes are:

1.  **Power Usage Over Reference Sensor:**
    - A new optional feature to calculate the total energy (kWh) consumed above a user-defined power reference (kW) for the previous day.
    - The feature is configured by selecting an `input_number` helper in the config flow, allowing the user to dynamically change their reference value.
    - A new sensor `..._yesterdays_power_usage_over_reference` is created if the feature is configured.

2.  **Expanded Historical Data:**
    - Adds a "Current Month" sensor for Gas Consumption.
    - Adds "Last Month" historical sensors for all 10 energy sharing and community-related OBIS codes.

3.  **Documentation:**
    - The `README.md` file has been updated to fully document the new "Power Usage Over Reference" feature, including setup instructions for the required helpers.
    - The sensor reference has been updated to include the new sensor.