### PR TITLE
feat: Add Power Usage Over Reference sensor

### DIFF
--- a/custom_components/leneda/const.py
+++ b/custom_components/leneda/const.py
@@ -8,6 +8,7 @@ CONF_API_KEY = "api_key"
 CONF_ENERGY_ID = "energy_id"
 CONF_METERING_POINT_ID = "metering_point_id"
 CONF_REFERENCE_POWER_ENTITY = "reference_power_entity"
+CONF_REFERENCE_POWER_STATIC = "reference_power_static"
 
 OBIS_CODES = {
     "1-1:1.29.0": {"name": "Measured Active Consumption", "unit": "kW", "service_type": "electricity"},

--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -26,7 +26,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_METERING_POINT_ID, DOMAIN, OBIS_CODES, GAS_OBIS_CODES
+from .const import (
+    CONF_METERING_POINT_ID,
+    DOMAIN,
+    OBIS_CODES,
+    GAS_OBIS_CODES,
+    CONF_REFERENCE_POWER_ENTITY,
+    CONF_REFERENCE_POWER_STATIC,
+)
 from .coordinator import LenedaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -107,7 +114,7 @@ async def async_setup_entry(
     ]
 
     # Conditionally add the power usage over reference sensor
-    if coordinator.reference_power_entity:
+    if coordinator.entry.data.get(CONF_REFERENCE_POWER_ENTITY) or coordinator.entry.data.get(CONF_REFERENCE_POWER_STATIC) is not None:
         all_sensors_ordered.append(
             ("yesterdays_power_usage_over_reference", "50 - Yesterday's Power Usage Over Reference", "energy")
         )


### PR DESCRIPTION
This commit adds a new feature to calculate the total energy consumed above a user-defined reference power limit.

The key changes are:
- The configuration flow is updated to allow the user to provide the reference power value, either by selecting an `input_number` entity or by entering a static number.
- The coordinator now fetches the 15-minute consumption data for the previous day and calculates the total energy (kWh) consumed in intervals where the power was above the configured reference.
- A new sensor, "Yesterday's Power Usage Over Reference", is conditionally created if the feature is configured.
- The README.md file is updated with comprehensive instructions on how to set up and use this new feature.