### PR TITLE
feat!: Improve naming and force entity recreation

### DIFF
--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -119,6 +119,7 @@ async def async_setup_entry(
             ("yesterdays_power_usage_over_reference", "50 - Yesterday's Power Usage Over Reference", "energy")
         )
 
+    # The _v3 suffix on unique_id is applied to all sensors below to force entity recreation.
     sensors = []
     _LOGGER.debug("Creating sensors in the following order:")
     for key, name, sensor_type in all_sensors_ordered:
@@ -156,7 +157,7 @@ class LenedaSensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorEntity)
         super().__init__(coordinator)
         self._obis_code = obis_code
         self._attr_name = details["name"]
-        self._attr_unique_id = f"{metering_point_id}_{obis_code}_v2"
+        self._attr_unique_id = f"{metering_point_id}_{obis_code}_v3"
         self._attr_native_unit_of_measurement = details["unit"]
 
         # Set device class, state class, and icon based on OBIS code and unit
@@ -293,7 +294,7 @@ class LenedaEnergySensor(CoordinatorEntity[LenedaDataUpdateCoordinator], SensorE
         super().__init__(coordinator)
         self._key = sensor_key
         self._attr_name = name
-        self._attr_unique_id = f"{metering_point_id}_{sensor_key}_v2"
+        self._attr_unique_id = f"{metering_point_id}_{sensor_key}_v3"
 
         # Set device class and icon based on sensor type (gas or energy)
         if sensor_key.startswith("g_"):


### PR DESCRIPTION
This commit introduces several improvements and a breaking change to the Leneda integration.

- **feat: Use more digits for friendly meter names** The friendly name for meters is now generated using the last 7 digits of the meter ID instead of 4. This prevents naming conflicts for users with similar meter IDs.

- **feat: Rename 'Self-Consumed' to 'Locally Used'** The "Self-Consumed Energy" sensors have been renamed to "Locally Used Energy". This new name more accurately reflects that the energy is used on-site, which can include both self-consumption and sharing within an energy community.

- **BREAKING CHANGE: Force entity recreation** The `unique_id` of all sensors has been changed from `_v2` to `_v3`. This will force Home Assistant to create new sensor entities with an `entity_id` that reflects the more unique device name. Users will need to update their dashboards and automations to use the new `entity_id`s. The old entities will become unavailable and can be removed from the UI.

- **docs: Add comment to clarify `unique_id` change** A comment has been added to the code to make it clear that the `unique_id` change is applied to all sensors.