### PR TITLE
feat: Add monthly power usage over reference sensors

### DIFF
--- a/custom_components/leneda/sensor.py
+++ b/custom_components/leneda/sensor.py
@@ -115,9 +115,11 @@ async def async_setup_entry(
 
     # Conditionally add the power usage over reference sensor
     if coordinator.entry.data.get(CONF_REFERENCE_POWER_ENTITY) or coordinator.entry.data.get(CONF_REFERENCE_POWER_STATIC) is not None:
-        all_sensors_ordered.append(
-            ("yesterdays_power_usage_over_reference", "50 - Yesterday's Power Usage Over Reference", "energy")
-        )
+        all_sensors_ordered.extend([
+            ("yesterdays_power_usage_over_reference", "50 - Yesterday's Power Usage Over Reference", "energy"),
+            ("current_month_power_usage_over_reference", "51 - Current Month's Power Usage Over Reference", "energy"),
+            ("last_month_power_usage_over_reference", "52 - Last Month's Power Usage Over Reference", "energy"),
+        ])
 
     # The _v3 suffix on unique_id is applied to all sensors below to force entity recreation.
     sensors = []


### PR DESCRIPTION
This commit introduces two new sensors to track power usage over a configured reference value for the current and previous month. This makes it easier for users to estimate costs related to demand charges on their energy bills.

- Adds API calls to fetch 15-minute interval data for the current and last month.
- Adds `current_month_power_usage_over_reference` and `last_month_power_usage_over_reference` sensors.
- Refactors the calculation logic into a reusable helper function.
- Updates the README to document the new sensors.
- Simplifies the advanced usage examples in the README to use the new native sensors, removing the need for manual `utility_meter` and `template` helpers.