### PR TITLE
Fix Leneda integration loading and I/O issues

### DIFF
--- a/custom_components/leneda/__init__.py
+++ b/custom_components/leneda/__init__.py
@@ -31,8 +31,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = LenedaDataUpdateCoordinator(hass, api_client, metering_point_id, entry)
 
     manifest_path = Path(__file__).parent / "manifest.json"
-    with manifest_path.open() as manifest_file:
-        manifest_data = json.load(manifest_file)
+
+    def load_manifest():
+        """Load the manifest file."""
+        with manifest_path.open() as manifest_file:
+            return json.load(manifest_file)
+
+    manifest_data = await hass.async_add_executor_job(load_manifest)
     coordinator.version = manifest_data.get("version")
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/leneda/services.yaml
+++ b/custom_components/leneda/services.yaml
@@ -1,0 +1,28 @@
+request_data_access:
+  name: Request Data Access
+  description: "Requests access to metering data from another party."
+  fields:
+    from_energy_id:
+      name: "From Energy ID"
+      description: "The energy ID of the party requesting access."
+      required: true
+      selector:
+        text:
+    from_name:
+      name: "From Name"
+      description: "The name of the party requesting access."
+      required: true
+      selector:
+        text:
+    metering_point_codes:
+      name: "Metering Point Codes"
+      description: "A list of metering point codes to request access for."
+      required: true
+      selector:
+        object:
+    obis_codes:
+      name: "OBIS Codes"
+      description: "A list of OBIS codes to request access for."
+      required: true
+      selector:
+        object:


### PR DESCRIPTION
This commit addresses two critical issues that prevented the Leneda integration from loading correctly:

1.  **Missing `services.yaml`:** The `services.yaml` file was missing, which caused an error when Home Assistant tried to load the integration's services. This commit adds the necessary `services.yaml` file with the definition for the `request_data_access` service.

2.  **Blocking I/O:** The `manifest.json` file was being read synchronously, which is not allowed in Home Assistant as it can block the event loop. This has been fixed by using `hass.async_add_executor_job` to read the file asynchronously.